### PR TITLE
Add workload preset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For a detailed setup and usage guide see [docs/USAGE_GUIDE.md](docs/USAGE_GUIDE.
 - **History** button in the Chat Bot panel opens a dashboard summarizing past runs.
 - Optional completion summary saved to a temporary folder (old entries are cleaned automatically).
 - Customizable artwork/template directories and adjustable UI font size.
+- Workload presets switch between customer-specific paths and preprocessing rules.
 - Optional Art Server and Google Drive paths with connectivity indicators.
 - Login details and settings persist in `settings.json` so the GUI stays ready between sessions.
 - The Diagnostic panel's **Open Art Directories** button shows all folders in a grid so you can monitor them live.

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -34,12 +34,13 @@ python order_gui.py
 ## 3. Initial Configuration
 
 1. Open the **Settings** tab.
-2. Set the path to *Adobe Illustrator* if the default does not match your system. You can browse for the executable using **Browse Illustrator**.
-3. If your order site requires authentication, enter the login URL, username and password, then click **Test Login**. A green indicator confirms success. Hidden form fields are detected automatically.
-4. Optionally specify paths for an **Art Server** and **Google Drive**. Use the respective **Login** buttons to verify connectivity. Status messages appear in the log panel.
-5. Provide your **ChatGPT API key** (and optionally a custom API URL) to enable the built-in chat panel. Choose **Login ChatGPT** to verify connection. The URL should end with `/v1` (the program appends it if needed).
-6. Select a GUI theme from the **Appearance** section. Choices are *System*, *Light* and *Dark*.
-6. Save your settings—they are stored in `settings.json` for next time.
+2. Choose a **Workload Preset** to fill in the default art and template folders.
+3. Set the path to *Adobe Illustrator* if the default does not match your system. You can browse for the executable using **Browse Illustrator**.
+4. If your order site requires authentication, enter the login URL, username and password, then click **Test Login**. A green indicator confirms success. Hidden form fields are detected automatically.
+5. Optionally specify paths for an **Art Server** and **Google Drive**. Use the respective **Login** buttons to verify connectivity. Status messages appear in the log panel.
+6. Provide your **ChatGPT API key** (and optionally a custom API URL) to enable the built-in chat panel. Choose **Login ChatGPT** to verify connection. The URL should end with `/v1` (the program appends it if needed).
+7. Select a GUI theme from the **Appearance** section. Choices are *System*, *Light* and *Dark*.
+8. Save your settings—they are stored in `settings.json` for next time.
 
 ## 4. Fetching Order Data
 

--- a/order_gui.py
+++ b/order_gui.py
@@ -91,6 +91,7 @@ def ensure_paper_summary_dir():
 
 
 SETTINGS_FILE = "settings.json"
+WORKLOADS_FILE = "workloads.json"
 TEMPLATE_SETTINGS_DIR = APP_DIR / "template_settings"
 
 # Base URL used when fetching an order by its number
@@ -155,6 +156,18 @@ def save_settings(data: dict):
             json.dump(data, f, ensure_ascii=False, indent=2)
     except Exception:
         traceback.print_exc()
+
+
+def load_workloads() -> dict:
+    """Return workload presets loaded from ``workloads.json``."""
+    path = APP_DIR / WORKLOADS_FILE
+    if path.exists():
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            traceback.print_exc()
+    return {}
 
 
 def load_template_settings(code: str) -> dict:
@@ -839,6 +852,9 @@ class App:
         self.run_start_time: float | None = None
         self.total_time_var = tk.StringVar(value="Total time: 0s")
 
+        self.workloads = load_workloads()
+        self.preset_var = tk.StringVar()
+
         container = tk.Frame(root)
         container.pack(fill="both", expand=True)
 
@@ -1148,6 +1164,7 @@ class App:
         self.chat_api_key_var.set(settings.get("chat_api_key", ""))
         self.chat_api_url_var.set(settings.get("chat_api_url", CHAT_API_URL))
         self.appearance_var.set(settings.get("appearance_mode", "System"))
+        self.preset_var.set(settings.get("preset", next(iter(self.workloads), "")))
         if ctk:
             ctk.set_appearance_mode(self.appearance_var.get())
 
@@ -1190,6 +1207,18 @@ class App:
         self.artids_entry.grid(row=row, column=1, columnspan=2, padx=5, pady=2, sticky="we")
 
         row = 0
+        tk.Label(paths_frame, text="Preset").grid(row=row, column=0, sticky="w")
+        preset_menu = ttk.Combobox(
+            paths_frame,
+            values=list(self.workloads.keys()),
+            textvariable=self.preset_var,
+            state="readonly",
+            width=20,
+        )
+        preset_menu.grid(row=row, column=1, padx=5, pady=2)
+        preset_menu.bind("<<ComboboxSelected>>", lambda e: self.apply_preset())
+        row += 1
+
         tk.Label(paths_frame, text="Art Folder").grid(row=row, column=0, sticky="w")
         tk.Entry(paths_frame, textvariable=self.art_dir_var, width=50).grid(row=row, column=1, padx=5, pady=2)
         tk.Button(paths_frame, text="Browse", command=self.browse_art_dir).grid(row=row, column=2, padx=5, pady=2)
@@ -1318,6 +1347,7 @@ class App:
 
 
         # Initialize status indicators
+        self.apply_preset()
         self.check_art_server()
         self.check_gdrive()
         self.update_chat_status()
@@ -1475,6 +1505,7 @@ class App:
             "appearance_mode": self.appearance_var.get(),
             "diagnostic_mode": self.diagnostic_var.get(),
             "review_flats": self.review_flats_var.get(),
+            "preset": self.preset_var.get(),
         }
         save_settings(data)
 
@@ -2017,6 +2048,8 @@ class App:
                 "order_id": self.order_id_var.get(),
                 "show_summary": self.summary_var.get(),
                 "diagnostic": self.diagnostic_var.get(),
+                "preset": self.preset_var.get(),
+                "preprocess": self.workloads.get(self.preset_var.get(), {}).get("preprocess", {}),
                 "order_info": {
                     "order_id": self.order_info_vars["order_id"].get(),
                     "company": self.order_info_vars["company"].get(),
@@ -2100,6 +2133,15 @@ class App:
         if chosen:
             self.gdrive_var.set(chosen)
             self.save_settings()
+
+    def apply_preset(self):
+        """Populate directories from the selected workload preset."""
+        preset = self.workloads.get(self.preset_var.get(), {})
+        if preset.get("art_dir"):
+            self.art_dir_var.set(preset["art_dir"])
+        if preset.get("template_dir"):
+            self.template_dir_var.set(preset["template_dir"])
+        self.save_settings()
 
     def open_art_dirs(self):
         """Open all detected artwork directories and arrange them."""
@@ -2611,6 +2653,8 @@ class App:
                 "order_id": self.order_id_var.get(),
                 "show_summary": self.summary_var.get(),
                 "diagnostic": self.diagnostic_var.get(),
+                "preset": self.preset_var.get(),
+                "preprocess": self.workloads.get(self.preset_var.get(), {}).get("preprocess", {}),
             }
         )
         self.save_settings()

--- a/template_creator.jsx
+++ b/template_creator.jsx
@@ -34,6 +34,9 @@ var TEMPLATE_ROOT = 'C:/Users/neone/My Drive (stevan.ybs@gmail.com)/DIE PRINT FI
 var ART_ROOT = '\\MCI2NAS/Art server';
 var SHOW_SUMMARY = false;
 var DIAGNOSTIC_MODE = false;
+var PRESET = '';
+var PRE_SHIFT_X = 0;
+var PRE_SHIFT_Y = 0;
 var PRINT_FOLDER_NAME = 'print';
 var PROGRESS_FILE = 'jsx_progress.txt';
 var PAUSE_FILE = 'jsx_pause.flag';
@@ -278,6 +281,13 @@ function loadInitialOrder() {
         if (obj && typeof obj.diagnostic !== 'undefined') {
             DIAGNOSTIC_MODE = !!obj.diagnostic;
         }
+        if (obj && obj.preset) {
+            PRESET = obj.preset;
+        }
+        if (obj && obj.preprocess) {
+            PRE_SHIFT_X = obj.preprocess.shift_x || 0;
+            PRE_SHIFT_Y = obj.preprocess.shift_y || 0;
+        }
         return obj;
     }
     var htmlFile = File(scriptDir + '/order.html');
@@ -330,7 +340,9 @@ function buildOptions(data) {
         pairs: out,
         vista: false,
         artDir: data.art_dir || ART_ROOT,
-        templateDir: data.template_dir || TEMPLATE_ROOT
+        templateDir: data.template_dir || TEMPLATE_ROOT,
+        preset: data.preset || PRESET,
+        preprocess: data.preprocess || { shift_x: PRE_SHIFT_X, shift_y: PRE_SHIFT_Y }
     };
 }
 
@@ -744,7 +756,9 @@ function showInputDialog(orderItems, pairInfo) {
         pairs: files,
         vista: vistaCheck.value,
         artDir: ART_ROOT,
-        templateDir: TEMPLATE_ROOT
+        templateDir: TEMPLATE_ROOT,
+        preset: PRESET,
+        preprocess: { shift_x: PRE_SHIFT_X, shift_y: PRE_SHIFT_Y }
     };
 }
 
@@ -1035,6 +1049,14 @@ function main() {
 
     if (opts.artDir) ART_ROOT = opts.artDir;
     if (opts.templateDir) TEMPLATE_ROOT = opts.templateDir;
+    if (opts.preset) PRESET = opts.preset;
+    if (opts.preprocess) {
+        PRE_SHIFT_X = opts.preprocess.shift_x || PRE_SHIFT_X;
+        PRE_SHIFT_Y = opts.preprocess.shift_y || PRE_SHIFT_Y;
+    }
+    if (PRESET === 'Vista' && !data.art_dir) {
+        ART_ROOT = 'C:/Vista/Art';
+    }
 
     var summaryItems = [];
     var summaryFolder = null;
@@ -1208,6 +1230,9 @@ function processPair(pair, index) {
         waitStep();
 
         writeProgress('Aligning artwork');
+        if (PRE_SHIFT_X || PRE_SHIFT_Y) {
+            pasted.translate(PRE_SHIFT_X, PRE_SHIFT_Y);
+        }
         alignGroupToPath(pasted, bleedPaths[bi2]);
         waitStep();
         writeProgress('  Alignment done');

--- a/tests/test_workloads.py
+++ b/tests/test_workloads.py
@@ -1,0 +1,13 @@
+import unittest
+from order_gui import load_workloads
+
+class WorkloadPresetTest(unittest.TestCase):
+    def test_presets_available(self):
+        data = load_workloads()
+        self.assertIn("YBS", data)
+        self.assertIn("Vista", data)
+        self.assertIn("art_dir", data["YBS"])
+        self.assertIn("template_dir", data["Vista"])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workloads.json
+++ b/workloads.json
@@ -1,0 +1,12 @@
+{
+  "YBS": {
+    "art_dir": "\\\\MCI2NAS/Art server",
+    "template_dir": "C:/Users/neone/My Drive (stevan.ybs@gmail.com)/DIE PRINT FILE SETUPS",
+    "preprocess": {"shift_x": 0, "shift_y": 0}
+  },
+  "Vista": {
+    "art_dir": "C:/Vista/Art",
+    "template_dir": "C:/Vista/Templates",
+    "preprocess": {"shift_x": 10, "shift_y": 0}
+  }
+}


### PR DESCRIPTION
## Summary
- add `workloads.json` defining YBS and Vista presets
- update `order_gui.py` to load presets, add preset dropdown, and store the preset in `settings.json`
- include preset info in `order_data.json`
- update Illustrator script to handle preset and preprocessing offsets
- document preset selection in README and usage guide
- add tests for preset loading

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686339ecb450832dbe53e4ca7ecd2bbe