### PR TITLE
Implement YBS proof import

### DIFF
--- a/order_gui.py
+++ b/order_gui.py
@@ -2036,6 +2036,7 @@ class App:
                     "template_path": temp_path,
                     "paperType": paper,
                     "lamType": lam,
+                    "order_id": order_id,
                 }
             )
         save_order_data(

--- a/template_creator.jsx
+++ b/template_creator.jsx
@@ -327,6 +327,7 @@ function buildOptions(data) {
             templateCode: pair.template || item.templateName || '',
             laminate: lam,
             paper: paper,
+            orderId: pair.order_id || '',
             orderData: {
                 info: item.info || '',
                 gluetab: item.gluetab || '',
@@ -1146,16 +1147,47 @@ function main() {
 function processPair(pair, index) {
     var orderData = pair.orderData || { info: '', gluetab: '', filename: '' };
 
-    writeProgress('Opening artwork "' + pair.artFile.name + '"');
-    var artworkDoc = app.open(pair.artFile);
-    waitStep();
-    writeProgress('  Artwork loaded');
-
     var tmplName = pair.templateFile.name.toLowerCase();
     var isCD0434 = tmplName.indexOf('cd0434') !== -1;
     var isPB001 = tmplName.indexOf('pb001') !== -1;
     var isPB005 = tmplName.indexOf('pb005') !== -1;
     var settings = loadTemplateSettings(pair.templateCode);
+
+    var artworkDoc, clipGroup;
+
+    if (PRESET === 'YBS') {
+        var artDir = pair.artFile.parent;
+        var proofDir = artDir ? artDir.parent : null;
+        if (!proofDir) throw new Error('Invalid art directory');
+        proofDir = Folder(proofDir.fsName + '/proof');
+        var proofFile = File(proofDir.fsName + '/' + pair.orderId + '.' + (index + 1) + '.pdf');
+        writeProgress('Opening proof "' + proofFile.name + '"');
+        artworkDoc = app.open(proofFile);
+        waitStep();
+        writeProgress('  Proof opened');
+        clipGroup = findNamedItem(artworkDoc, 'Clip Group');
+        if (!clipGroup) {
+            artworkDoc.close(SaveOptions.DONOTSAVECHANGES);
+            throw new Error('Clip Group not found.');
+        }
+    } else {
+        writeProgress('Opening artwork "' + pair.artFile.name + '"');
+        artworkDoc = app.open(pair.artFile);
+        waitStep();
+        writeProgress('  Artwork loaded');
+
+        writeProgress('Finding bleed path in artwork');
+        var bleedGroup = isCD0434 ?
+            findTopBleedPath(artworkDoc, true) :
+            findBleedPath(artworkDoc, isArtBleedColor, true);
+        waitStep();
+        writeProgress('  Bleed path located');
+
+        writeProgress('Creating clipping mask');
+        clipGroup = createClippingGroup(artworkDoc, bleedGroup);
+        waitStep();
+        writeProgress('  Clip group created');
+    }
 
     writeProgress('Finding bleed path in artwork');
     var bleedGroup = isCD0434 ?


### PR DESCRIPTION
## Summary
- include order ID with pairs when saving JSON
- store orderId in template options
- load <Clip Group> from proof PDF when preset is YBS

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863412a9d10832d8b919dfae2e1da5e