### PR TITLE
Implement YBS proof search

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ For a detailed setup and usage guide see [docs/USAGE_GUIDE.md](docs/USAGE_GUIDE.
 - Positions artwork to the template's `Bleed` path and centers the clipping group after detecting bleed bounds.
 - Adds a laminate label, updates version text and inserts delays to keep Illustrator responsive.
 - Template files must include `<template>_print` and `-vp` for recognition.
+- When the **YBS** preset is selected, the script copies the `Clip Group` from the
+  order's proof PDF instead of generating a new clipping mask. Proof files are
+  located by searching the selected month directory for `<order>/proof` folders.
 
 ### Output
 - Exports both `*_lines_` and `*_flat_` PDFs for each pair.

--- a/order_gui.py
+++ b/order_gui.py
@@ -470,6 +470,51 @@ def find_art_file(
     return ""
 
 
+def find_order_dir(month_dir: str, order_id: str) -> str:
+    """Return the directory path for ``order_id`` under ``month_dir``.
+
+    Searches recursively and returns the first matching directory name. If no
+    directory is found, an empty string is returned.
+    """
+    if not month_dir or not order_id:
+        return ""
+
+    order_id_str = str(order_id)
+    for dirpath, dirs, _ in os.walk(month_dir):
+        for d in dirs:
+            if d == order_id_str:
+                return os.path.join(dirpath, d)
+    return ""
+
+
+def find_proof_file(month_dir: str, order_id: str, pair_num: int) -> str:
+    """Locate a proof PDF for ``order_id`` and ``pair_num`` inside ``month_dir``.
+
+    The search looks for ``<order_id>/proof`` and returns the first file whose
+    name begins with ``<order_id>.<pair_num>``. Returns an empty string if no
+    match is found.
+    """
+
+    if not month_dir or not order_id or not pair_num:
+        return ""
+
+    order_dir = find_order_dir(month_dir, order_id)
+    if not order_dir:
+        return ""
+
+    proof_dir = os.path.join(order_dir, "proof")
+    if not os.path.isdir(proof_dir):
+        return ""
+
+    prefix = f"{order_id}.{pair_num}".lower()
+    for name in os.listdir(proof_dir):
+        if not name.lower().startswith(prefix):
+            continue
+        if name.lower().endswith((".ai", ".pdf")):
+            return os.path.join(proof_dir, name)
+    return ""
+
+
 def find_template_file(root: str, template: str, sample: bool = False) -> str:
     """Return the template file path for ``template``.
 
@@ -2022,22 +2067,27 @@ class App:
             month_root = it.get("month_dir", self.month_dir_var.get())
             order_id = it.get("order_id", self.order_id_var.get())
             art_path = find_art_file(art_root, art_id, month_root, order_id)
+            proof_path = ""
+            if self.preset_var.get() == "YBS":
+                proof_path = find_proof_file(month_root, order_id, idx + 1)
             temp_path = find_template_file(temp_root, template)
             paper = extract_paper_type(temp_path)
             lam = it.get("lamType", "") or detect_laminate(it.get("info", ""))
             if not lam and is_coffee_sleeve(template):
                 lam = "Uncoated"
             it["paperType"] = paper
-            pairs_data.append(
-                {
-                    "art_id": art_id,
-                    "template": template,
-                    "art_path": art_path,
-                    "template_path": temp_path,
-                    "paperType": paper,
-                    "lamType": lam,
-                }
-            )
+            pair_entry = {
+                "art_id": art_id,
+                "template": template,
+                "art_path": art_path,
+                "template_path": temp_path,
+                "paperType": paper,
+                "lamType": lam,
+                "order_id": order_id,
+            }
+            if proof_path:
+                pair_entry["proof_path"] = proof_path
+            pairs_data.append(pair_entry)
         save_order_data(
             {
                 "items": items,
@@ -2624,7 +2674,10 @@ class App:
                 if sample:
                     cut_src = cut_file_for_template(temp_path)
                     self.sample_copy_info.append((cut_src, os.path.join(dest_root, folder)))
-            pairs_data.append({
+            proof_path = ""
+            if self.preset_var.get() == "YBS":
+                proof_path = find_proof_file(month_root, order_id, idx + 1)
+            pair_info = {
                 "art_id": art_id,
                 "template": template,
                 "art_path": art_path,
@@ -2633,7 +2686,10 @@ class App:
                 "paperType": paper,
                 "lamType": lam,
                 "order_id": order_id,
-            })
+            }
+            if proof_path:
+                pair_info["proof_path"] = proof_path
+            pairs_data.append(pair_info)
             pair_orders.append(order_id)
 
         self.pending_flat_paths = [p for p in flat_paths if p]

--- a/template_creator.jsx
+++ b/template_creator.jsx
@@ -323,10 +323,12 @@ function buildOptions(data) {
         var paper = pair.paperType || item.paperType || '';
         out.push({
             artFile: File(pair.art_path),
+            proofFile: pair.proof_path ? File(pair.proof_path) : null,
             templateFile: File(pair.template_path),
             templateCode: pair.template || item.templateName || '',
             laminate: lam,
             paper: paper,
+            orderId: pair.order_id || '',
             orderData: {
                 info: item.info || '',
                 gluetab: item.gluetab || '',
@@ -1146,28 +1148,46 @@ function main() {
 function processPair(pair, index) {
     var orderData = pair.orderData || { info: '', gluetab: '', filename: '' };
 
-    writeProgress('Opening artwork "' + pair.artFile.name + '"');
-    var artworkDoc = app.open(pair.artFile);
-    waitStep();
-    writeProgress('  Artwork loaded');
-
     var tmplName = pair.templateFile.name.toLowerCase();
     var isCD0434 = tmplName.indexOf('cd0434') !== -1;
     var isPB001 = tmplName.indexOf('pb001') !== -1;
     var isPB005 = tmplName.indexOf('pb005') !== -1;
     var settings = loadTemplateSettings(pair.templateCode);
 
-    writeProgress('Finding bleed path in artwork');
-    var bleedGroup = isCD0434 ?
-        findTopBleedPath(artworkDoc, true) :
-        findBleedPath(artworkDoc, isArtBleedColor, true);
-    waitStep();
-    writeProgress('  Bleed path located');
+    var artworkDoc, clipGroup, bleedGroup;
 
-    writeProgress('Creating clipping mask');
-    var clipGroup = createClippingGroup(artworkDoc, bleedGroup);
-    waitStep();
-    writeProgress('  Clip group created');
+    if (PRESET === 'YBS') {
+        var proofFile = pair.proofFile;
+        if (!proofFile || !proofFile.exists) {
+            throw new Error('Proof not found: ' + (proofFile ? proofFile.fsName : ''));
+        }
+        writeProgress('Opening proof "' + proofFile.name + '"');
+        artworkDoc = app.open(proofFile);
+        waitStep();
+        writeProgress('  Proof opened');
+        clipGroup = findNamedItem(artworkDoc, 'Clip Group');
+        if (!clipGroup) {
+            artworkDoc.close(SaveOptions.DONOTSAVECHANGES);
+            throw new Error('Clip Group not found.');
+        }
+    } else {
+        writeProgress('Opening artwork "' + pair.artFile.name + '"');
+        artworkDoc = app.open(pair.artFile);
+        waitStep();
+        writeProgress('  Artwork loaded');
+
+        writeProgress('Finding bleed path in artwork');
+        bleedGroup = isCD0434 ?
+            findTopBleedPath(artworkDoc, true) :
+            findBleedPath(artworkDoc, isArtBleedColor, true);
+        waitStep();
+        writeProgress('  Bleed path located');
+
+        writeProgress('Creating clipping mask');
+        clipGroup = createClippingGroup(artworkDoc, bleedGroup);
+        waitStep();
+        writeProgress('  Clip group created');
+    }
 
     writeProgress('Opening template "' + pair.templateFile.name + '"');
     var templateDoc = app.open(pair.templateFile);

--- a/tests/test_find_proof_file.py
+++ b/tests/test_find_proof_file.py
@@ -1,0 +1,20 @@
+import unittest
+import tempfile
+import os
+from order_gui import find_proof_file
+
+class FindProofFileTest(unittest.TestCase):
+    def test_find_proof_recursive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            month_dir = tmp
+            order_dir = os.path.join(month_dir, "Company", "12345")
+            proof_dir = os.path.join(order_dir, "proof")
+            os.makedirs(proof_dir)
+            fname = "12345.1-test.pdf"
+            open(os.path.join(proof_dir, fname), "w").close()
+
+            path = find_proof_file(month_dir, "12345", 1)
+            self.assertEqual(path, os.path.join(proof_dir, fname))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- look for proof files in month folder when preset is YBS
- add helper functions `find_order_dir` and `find_proof_file`
- include proof_path in saved pairs and forward to Illustrator
- update Illustrator script to open passed proof file
- document YBS proof search behavior
- test proof file lookup

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863412a9d10832d8b919dfae2e1da5e