### PR TITLE
Enhance YBS proof lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ the main workflow and utility functions used.
 
 ## YBS Preset Helper
 
-`preset_ybs.py` contains helper logic for locating artwork when the YBS preset is active. The helper `fetch_art(settings, order_number, pair_num)` now searches the month directory under the company and order number. When a `proof` folder exists the pair files are used. Otherwise the order directory is scanned for PDFs containing `proof` with version suffixes (`v1`, `v2`, etc.) and the highest version is returned. A `ValueError("Refusing…")` is raised if the resolved path includes a `$recycle` segment.
+`preset_ybs.py` contains helper logic for locating artwork when the YBS preset is active. The helper `fetch_art(settings, order_number, pair_num)` now scans the configured month directory for any folder named after the order number. If a `proof` subfolder is present the pair files are used. Otherwise the order directory is scanned for PDFs containing `proof` with version suffixes (`v1`, `v2`, etc.) and the highest version is returned. A `ValueError("Refusing…")` is raised if the resolved path includes a `$recycle` segment.
 
 ## Template Settings
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ the main workflow and utility functions used.
 
 ## YBS Preset Helper
 
-`preset_ybs.py` contains helper logic for locating artwork when the YBS preset is active. Its function `fetch_art(settings, order_number, pair_num)` searches the configured folders using `Path.rglob` and returns the first match. A `ValueError("Refusing…")` is raised if the resolved path includes a `$recycle` segment.
+`preset_ybs.py` contains helper logic for locating artwork when the YBS preset is active. The helper `fetch_art(settings, order_number, pair_num)` now searches the month directory under the company and order number. When a `proof` folder exists the pair files are used. Otherwise the order directory is scanned for PDFs containing `proof` with version suffixes (`v1`, `v2`, etc.) and the highest version is returned. A `ValueError("Refusing…")` is raised if the resolved path includes a `$recycle` segment.
 
 ## Template Settings
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ the main workflow and utility functions used.
 
 ## YBS Preset Helper
 
-`preset_ybs.py` contains helper logic for locating artwork when the YBS preset is active. The helper `fetch_art(settings, order_number, pair_num)` now scans the configured month directory for any folder named after the order number. If a `proof` subfolder is present the pair files are used. Otherwise the order directory is scanned for PDFs containing `proof` with version suffixes (`v1`, `v2`, etc.) and the highest version is returned. A `ValueError("Refusing…")` is raised if the resolved path includes a `$recycle` segment.
+`preset_ybs.py` contains helper logic for locating artwork when the YBS preset is active. The helper `fetch_art(settings, order_number, pair_num)` scans the configured month directory and looks for a folder named after the order number beneath any company folder. If a `proof` subfolder exists the pair files (e.g. `<order>.<pair>.pdf`) are used. When no `proof` folder is present the order directory itself is searched for PDFs containing `proof` with version suffixes (`v1`, `v2`, ...); the highest version is chosen. A `ValueError("Refusing…")` is raised if the resolved path includes a `$recycle` segment.
 
 ## Template Settings
 

--- a/order_gui.py
+++ b/order_gui.py
@@ -2029,7 +2029,6 @@ class App:
                             "art_dir": art_root,
                             "month_dir": month_root,
                             "art_server_path": self.art_server_var.get(),
-                            "company": it.get("company", self.order_info_vars["company"].get()),
                         },
                         str(order_id),
                         idx + 1,

--- a/order_gui.py
+++ b/order_gui.py
@@ -2029,6 +2029,7 @@ class App:
                             "art_dir": art_root,
                             "month_dir": month_root,
                             "art_server_path": self.art_server_var.get(),
+                            "company": it.get("company", self.order_info_vars["company"].get()),
                         },
                         str(order_id),
                         idx + 1,

--- a/preset_ybs.py
+++ b/preset_ybs.py
@@ -7,18 +7,19 @@ def fetch_art(settings: dict, order_number: str, pair_num: int) -> Path:
     """Return the artwork path for ``order_number`` and ``pair_num``.
 
     The search first checks the configured month directory. Any folder named
-    after the ``order_number`` is considered the order root regardless of the
-    company path above it. If a ``proof`` subfolder exists it is searched for
-    pair files. Otherwise the order directory itself is scanned for PDFs
-    containing ``proof`` with version suffixes (``v1``, ``v2`` ...); the highest
-    version is returned. If nothing is found there, the main art directory is
-    searched next.
+    after ``order_number`` is considered an order root no matter which company
+    folder it resides in.  If a ``proof`` subfolder exists inside an order
+    directory, it is searched for pair files like ``<order>.<pair>.pdf``.  When
+    there is no ``proof`` folder, the order directory itself is scanned for PDF
+    files containing ``proof`` followed by a version suffix (``v1``, ``v2``,
+    ...); the highest version found is returned.  If nothing is found there, the
+    main art directory is searched next.
     """
     logger = logging.getLogger(__name__)
     order_number = str(order_number).strip()
     pair_suffix = f"#{pair_num}"
-    candidates: list[Path] = []
-    order_roots: list[Path] = []
+    proof_dirs: list[Path] = []
+    order_dirs: list[Path] = []
 
     month_dir = settings.get("month_dir")
     if month_dir:
@@ -26,20 +27,15 @@ def fetch_art(settings: dict, order_number: str, pair_num: int) -> Path:
         if base.exists():
             for p in base.rglob(order_number):
                 if p.is_dir():
-                    order_roots.append(p)
-                    proof_dir = p / "proof"
-                    if proof_dir.exists():
-                        candidates.append(proof_dir)
-                    candidates.extend([p / "art", p])
-
-    art_root = settings.get("art_dir") or settings.get("art_server_path")
-    if art_root:
-        candidates.append(Path(art_root))
+                    order_dirs.append(p)
+                    proof = p / "proof"
+                    if proof.exists():
+                        proof_dirs.append(proof)
 
     patterns = [f"{order_number}.{pair_num}.pdf", f"*_{pair_suffix}.*"]
 
-    for base in candidates:
-        if not base or not base.exists():
+    for base in proof_dirs:
+        if not base.exists():
             continue
         for pattern in patterns:
             logger.info("Searching %s for pattern %s", base, pattern)
@@ -50,11 +46,24 @@ def fetch_art(settings: dict, order_number: str, pair_num: int) -> Path:
                 logger.info("Found %s", resolved)
                 return resolved
 
+    art_root = settings.get("art_dir") or settings.get("art_server_path")
+    if art_root:
+        base = Path(art_root)
+        if base.exists():
+            for pattern in patterns:
+                logger.info("Searching %s for pattern %s", base, pattern)
+                for path in base.rglob(pattern):
+                    resolved = path.resolve()
+                    if "$recycle" in str(resolved).lower():
+                        raise ValueError("Refusing…")
+                    logger.info("Found %s", resolved)
+                    return resolved
+
     # Fallback: search order directories for highest proof version
-    for root in order_roots:
+    for root in order_dirs:
         best: Path | None = None
         best_version = -1
-        for path in root.glob("*.pdf"):
+        for path in root.rglob("*.pdf"):
             name = path.name.lower()
             if "proof" not in name:
                 continue

--- a/preset_ybs.py
+++ b/preset_ybs.py
@@ -1,34 +1,41 @@
 import logging
 from pathlib import Path
+import re
 
 
 def fetch_art(settings: dict, order_number: str, pair_num: int) -> Path:
     """Return the artwork path for ``order_number`` and ``pair_num``.
 
-    The search checks the month folder followed by the main art directory.
-    The first matching file found via ``Path.rglob`` is returned.
+    The search first checks the configured month directory which may include a
+    company subfolder. If a ``proof`` folder exists it is searched for pair
+    files. Otherwise the order directory itself is scanned for PDFs containing
+    ``proof`` with version suffixes (``v1``, ``v2`` ...); the highest version is
+    returned. If nothing is found there, the main art directory is searched next.
     """
     logger = logging.getLogger(__name__)
     order_number = str(order_number).strip()
     pair_suffix = f"#{pair_num}"
+    company = settings.get("company", "").strip()
     candidates: list[Path] = []
 
     month_dir = settings.get("month_dir")
+    order_root: Path | None = None
     if month_dir:
-        order_root = Path(month_dir) / order_number
-        candidates.extend([
-            order_root / "art",
-            order_root / "proof",
-        ])
+        order_root = Path(month_dir)
+        if company:
+            order_root = order_root / company / order_number
+        else:
+            order_root = order_root / order_number
+        proof_dir = order_root / "proof"
+        if proof_dir.exists():
+            candidates.append(proof_dir)
+        candidates.extend([order_root / "art", order_root])
 
     art_root = settings.get("art_dir") or settings.get("art_server_path")
     if art_root:
         candidates.append(Path(art_root))
 
-    patterns = [
-        f"{order_number}.{pair_num}.pdf",
-        f"*_{pair_suffix}.*",
-    ]
+    patterns = [f"{order_number}.{pair_num}.pdf", f"*_{pair_suffix}.*"]
 
     for base in candidates:
         if not base or not base.exists():
@@ -41,4 +48,24 @@ def fetch_art(settings: dict, order_number: str, pair_num: int) -> Path:
                     raise ValueError("Refusing…")
                 logger.info("Found %s", resolved)
                 return resolved
+
+    # Fallback: search order directory for highest proof version
+    if order_root and order_root.exists():
+        best: Path | None = None
+        best_version = -1
+        for path in order_root.glob("*.pdf"):
+            name = path.name.lower()
+            if "proof" not in name:
+                continue
+            m = re.search(r"v(\d+)", name)
+            version = int(m.group(1)) if m else 0
+            if version > best_version:
+                best_version = version
+                best = path.resolve()
+        if best:
+            if "$recycle" in str(best).lower():
+                raise ValueError("Refusing…")
+            logger.info("Selected %s", best)
+            return best
+
     raise FileNotFoundError(f"Art not found for order {order_number} pair {pair_num}")

--- a/preset_ybs.py
+++ b/preset_ybs.py
@@ -6,30 +6,31 @@ import re
 def fetch_art(settings: dict, order_number: str, pair_num: int) -> Path:
     """Return the artwork path for ``order_number`` and ``pair_num``.
 
-    The search first checks the configured month directory which may include a
-    company subfolder. If a ``proof`` folder exists it is searched for pair
-    files. Otherwise the order directory itself is scanned for PDFs containing
-    ``proof`` with version suffixes (``v1``, ``v2`` ...); the highest version is
-    returned. If nothing is found there, the main art directory is searched next.
+    The search first checks the configured month directory. Any folder named
+    after the ``order_number`` is considered the order root regardless of the
+    company path above it. If a ``proof`` subfolder exists it is searched for
+    pair files. Otherwise the order directory itself is scanned for PDFs
+    containing ``proof`` with version suffixes (``v1``, ``v2`` ...); the highest
+    version is returned. If nothing is found there, the main art directory is
+    searched next.
     """
     logger = logging.getLogger(__name__)
     order_number = str(order_number).strip()
     pair_suffix = f"#{pair_num}"
-    company = settings.get("company", "").strip()
     candidates: list[Path] = []
+    order_roots: list[Path] = []
 
     month_dir = settings.get("month_dir")
-    order_root: Path | None = None
     if month_dir:
-        order_root = Path(month_dir)
-        if company:
-            order_root = order_root / company / order_number
-        else:
-            order_root = order_root / order_number
-        proof_dir = order_root / "proof"
-        if proof_dir.exists():
-            candidates.append(proof_dir)
-        candidates.extend([order_root / "art", order_root])
+        base = Path(month_dir)
+        if base.exists():
+            for p in base.rglob(order_number):
+                if p.is_dir():
+                    order_roots.append(p)
+                    proof_dir = p / "proof"
+                    if proof_dir.exists():
+                        candidates.append(proof_dir)
+                    candidates.extend([p / "art", p])
 
     art_root = settings.get("art_dir") or settings.get("art_server_path")
     if art_root:
@@ -49,11 +50,11 @@ def fetch_art(settings: dict, order_number: str, pair_num: int) -> Path:
                 logger.info("Found %s", resolved)
                 return resolved
 
-    # Fallback: search order directory for highest proof version
-    if order_root and order_root.exists():
+    # Fallback: search order directories for highest proof version
+    for root in order_roots:
         best: Path | None = None
         best_version = -1
-        for path in order_root.glob("*.pdf"):
+        for path in root.glob("*.pdf"):
             name = path.name.lower()
             if "proof" not in name:
                 continue

--- a/tests/test_ybs_fetch.py
+++ b/tests/test_ybs_fetch.py
@@ -17,7 +17,7 @@ class FetchArtTest(unittest.TestCase):
             pair1.write_text("a")
             pair2.write_text("b")
 
-            settings = {"month_dir": str(month_dir), "company": "ACME"}
+            settings = {"month_dir": str(month_dir)}
             self.assertEqual(fetch_art(settings, "56789", 1), pair1.resolve())
             self.assertEqual(fetch_art(settings, "56789", 2), pair2.resolve())
 
@@ -29,7 +29,7 @@ class FetchArtTest(unittest.TestCase):
             bad = recycle / "12345.1.pdf"
             bad.write_text("x")
 
-            settings = {"month_dir": str(month_dir), "company": "ACME"}
+            settings = {"month_dir": str(month_dir)}
             with self.assertRaises(ValueError):
                 fetch_art(settings, "12345", 1)
 
@@ -44,7 +44,7 @@ class FetchArtTest(unittest.TestCase):
             v1.write_text("x")
             v2.write_text("y")
 
-            settings = {"month_dir": str(month_dir), "company": "ACME"}
+            settings = {"month_dir": str(month_dir)}
             self.assertEqual(fetch_art(settings, "11111", 1), v2.resolve())
             self.assertEqual(fetch_art(settings, "11111", 2), v2.resolve())
 

--- a/tests/test_ybs_fetch.py
+++ b/tests/test_ybs_fetch.py
@@ -9,7 +9,7 @@ class FetchArtTest(unittest.TestCase):
     def test_month_dir_pairs(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             month_dir = Path(tmpdir)
-            order_root = month_dir / "56789" / "proof"
+            order_root = month_dir / "ACME" / "56789" / "proof"
             order_root.mkdir(parents=True)
 
             pair1 = order_root / "56789.1.pdf"
@@ -17,21 +17,36 @@ class FetchArtTest(unittest.TestCase):
             pair1.write_text("a")
             pair2.write_text("b")
 
-            settings = {"month_dir": str(month_dir)}
+            settings = {"month_dir": str(month_dir), "company": "ACME"}
             self.assertEqual(fetch_art(settings, "56789", 1), pair1.resolve())
             self.assertEqual(fetch_art(settings, "56789", 2), pair2.resolve())
 
     def test_recycle_rejected(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             month_dir = Path(tmpdir)
-            recycle = month_dir / "12345" / "proof" / "$Recycle.Bin"
+            recycle = month_dir / "ACME" / "12345" / "proof" / "$Recycle.Bin"
             recycle.mkdir(parents=True)
             bad = recycle / "12345.1.pdf"
             bad.write_text("x")
 
-            settings = {"month_dir": str(month_dir)}
+            settings = {"month_dir": str(month_dir), "company": "ACME"}
             with self.assertRaises(ValueError):
                 fetch_art(settings, "12345", 1)
+
+    def test_version_fallback(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            month_dir = Path(tmpdir)
+            order_root = month_dir / "ACME" / "11111"
+            order_root.mkdir(parents=True)
+
+            v1 = order_root / "order11111 proof v1.pdf"
+            v2 = order_root / "order11111 proof v2.pdf"
+            v1.write_text("x")
+            v2.write_text("y")
+
+            settings = {"month_dir": str(month_dir), "company": "ACME"}
+            self.assertEqual(fetch_art(settings, "11111", 1), v2.resolve())
+            self.assertEqual(fetch_art(settings, "11111", 2), v2.resolve())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- improve YBS preset artwork search
- include company info when locating proofs
- pick newest proof PDF when no proof folder exists
- update documentation
- extend YBS proof search tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686358a69848832db72938186346e0c1